### PR TITLE
Get Cert Publishers by SID instead of by name

### DIFF
--- a/Test-MdiReadiness/Test-MdiReadiness.ps1
+++ b/Test-MdiReadiness/Test-MdiReadiness.ps1
@@ -843,7 +843,8 @@ function Get-mdiCAReadiness {
     if ([string]::IsNullOrEmpty($CAServer)) {
         Write-Verbose -Message "Searching for CA servers in $Domain"
         try {
-            $CAServer = Get-ADGroupMember -Server $Domain -Identity 'Cert Publishers' -ErrorAction Stop | Where-Object { $_.objectClass -eq 'computer' }
+            $CertPublishersSID = $((Get-ADDomain).DomainSID.Value + "-517")
+            $CAServer = Get-ADGroupMember -Server $Domain -Identity $CertPublishersSID -ErrorAction Stop | Where-Object { $_.objectClass -eq 'computer' }
         } catch {
             $CAServer = $null
         }


### PR DESCRIPTION
Make `Get-ADGroupMember -Identity 'Cert Publishers'` to work in any locale by using the SID instead of the name. Fixes #13.