### PR TITLE
Pass EntraConnectServer through to Get-mdiEntraConnectReadiness

### DIFF
--- a/Test-MdiReadiness/Test-MdiReadiness.ps1
+++ b/Test-MdiReadiness/Test-MdiReadiness.ps1
@@ -1208,7 +1208,7 @@ if ($PSCmdlet.ShouldProcess($Domain, 'Create MDI related configuration reports')
         $report.CAServers = Get-mdiCAReadiness -Domain $Domain -CAServer $CAServer
     }
     if (-not $SkipEntraConnect) {
-        $report.EntraConnectServers = Get-mdiEntraConnectReadiness -Domain $Domain
+        $report.EntraConnectServers = Get-mdiEntraConnectReadiness -Domain $Domain -EntraConnectServer $EntraConnectServer
     }
 
     $htmlReportFile = Set-MdiReadinessReport -Domain $Domain -Path $Path -ReportData $report


### PR DESCRIPTION
This fixes the use of `-EntraConnectServer <String[]>` so it can be used.

Before this change it never passed the value to the `Get-mdiEntraConnectReadiness` function, this change passes it into the function so it can be used.